### PR TITLE
adds save-performance rule

### DIFF
--- a/.github/workflows/callable_run.yml
+++ b/.github/workflows/callable_run.yml
@@ -199,6 +199,12 @@ jobs:
         COLLECTION_DATASET_BUCKET_NAME: ${{secrets.DEVELOPMENT_DATA_S3_BUCKET}}
       run: make save-expectations
 
+    - name: Save performance to Development S3
+      if: always()
+      env:
+        COLLECTION_DATASET_BUCKET_NAME: ${{secrets.DEVELOPMENT_DATA_S3_BUCKET}}
+      run: make save-performance
+
     - name: Configure Staging AWS Credentials
       if: always()
       uses: aws-actions/configure-aws-credentials@v1-node16
@@ -218,6 +224,12 @@ jobs:
       env:
         COLLECTION_DATASET_BUCKET_NAME: ${{secrets.STAGING_DATA_S3_BUCKET}}
       run: make save-expectations
+
+    - name: Save performance to Staging S3
+      if: always()
+      env:
+        COLLECTION_DATASET_BUCKET_NAME: ${{secrets.STAGING_DATA_S3_BUCKET}}
+      run: make save-performance
     
     - name: Configure Production AWS Credentials
       if: always()
@@ -238,6 +250,12 @@ jobs:
       env:
         COLLECTION_DATASET_BUCKET_NAME: ${{secrets.PRODUCTION_DATA_S3_BUCKET}}
       run: make save-expectations
+
+    - name: Save performance to Prod S3
+      if: always()
+      env:
+        COLLECTION_DATASET_BUCKET_NAME: ${{secrets.PRODUCTION_DATA_S3_BUCKET}}
+      run: make save-performance
 
   check-pipeline-errors:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A new rule has been added to makerules that is used to sync the performance directory to the s3 bucket. This rule needs to be called as part of the overnight pipeline run

## Related Tickets & Documents

https://trello.com/c/WqmRhmvR/3527-save-combined-operationalissue-csv-per-dataset-in-digital-land-python

## [optional] Are there any dependencies on other PRs or Work?

Needs to be merged after the following PR https://github.com/digital-land/makerules/pull/50